### PR TITLE
Karatsuba Polynomial Multiplication

### DIFF
--- a/include/karatsuba.hpp
+++ b/include/karatsuba.hpp
@@ -1,0 +1,83 @@
+#pragma once
+#include <CL/sycl.hpp>
+#include <cassert>
+
+namespace karatsuba {
+
+class kernelKaratsubaMultiplicationPhase0;
+class kernelKaratsubaMultiplicationPhase1;
+
+// Data-parallel Karatsuba polynomial multiplication, inspired from
+// https://github.com/tprest/falcon.py/blob/88d01ede1d7fa74a8392116bc5149dee57af93f2/ntrugen.py#L14-L39
+// ( recursive ) and https://eprint.iacr.org/2006/224.pdf ( see section 3.2 for
+// iterative implementation )
+std::vector<sycl::event>
+multiplication(sycl::queue& q,
+               const double* const __restrict src_a,
+               const size_t len_a,
+               const double* const __restrict src_b,
+               const size_t len_b,
+               double* const __restrict itmd,
+               const size_t len_itmd,
+               double* const __restrict dst,
+               const size_t len_dst,
+               const size_t wg_size,
+               std::vector<sycl::event> evts)
+{
+  assert(len_a == len_b);
+  assert(len_b == len_itmd);
+  assert((len_itmd << 1) == len_dst);
+  assert(len_itmd % wg_size == 0);        // all workgroups are of same size
+  assert((len_dst & (len_dst - 1)) == 0); // power of 2 many coefficients
+
+  sycl::event evt0 = q.submit([&](sycl::handler& h) {
+    h.depends_on(evts);
+
+    h.parallel_for<kernelKaratsubaMultiplicationPhase0>(
+      sycl::nd_range<1>{ len_itmd, wg_size }, [=](sycl::nd_item<1> it) {
+        const size_t idx = it.get_global_linear_id();
+
+        itmd[idx] = src_a[idx] * src_b[idx];
+      });
+  });
+
+  sycl::event evt1 = q.memset(dst, 0, sizeof(double) * len_dst);
+
+  sycl::event evt2 = q.submit([&](sycl::handler& h) {
+    h.depends_on({ evt0, evt1 });
+
+    h.parallel_for<kernelKaratsubaMultiplicationPhase1>(
+      sycl::nd_range<1>{ len_dst, wg_size }, [=](sycl::nd_item<1> it) {
+        const size_t idx = it.get_global_linear_id();
+
+        if (idx == 0) {
+          dst[idx] = itmd[idx];
+        } else if (idx == len_dst - 2) {
+          dst[idx] = itmd[len_itmd - 1];
+        } else {
+          double d_st = 0, d_s_t = 0;
+
+          for (size_t s = 0; s < idx; s++) {
+            size_t t = idx - s;
+
+            if ((len_itmd > t) && (t > s)) {
+              d_st += ((src_a[s] + src_a[t]) * (src_b[s] + src_b[t]));
+              d_s_t += (itmd[s] + itmd[t]);
+            }
+          }
+
+          if ((idx & 0b1) == 0) {
+            // even index
+            dst[idx] = d_st - d_s_t + itmd[idx >> 1];
+          } else {
+            // odd index
+            dst[idx] = d_st - d_s_t;
+          }
+        }
+      });
+  });
+
+  return { evt0, evt1, evt2 };
+}
+
+}

--- a/include/test_karatsuba.hpp
+++ b/include/test_karatsuba.hpp
@@ -1,0 +1,58 @@
+#pragma once
+#include "karatsuba.hpp"
+
+namespace test {
+
+// Tests data-parallel karatsuba polynomial multiplication implementation, **in a
+// static manner**
+//
+// @todo Improve test such that it can work for other input sizes and values.
+void
+karatsuba(sycl::queue& q)
+{
+  using namespace karatsuba;
+
+  const size_t i_dim = 8;
+  const size_t o_dim = i_dim << 1;
+  const size_t wg_size = 4;
+
+  std::vector<double> res = { 1,   4,   10,  20,  35,  56,  84, 120,
+                              147, 164, 170, 164, 145, 112, 64, 0 };
+
+  const size_t i_size = sizeof(double) * i_dim;
+  const size_t o_size = sizeof(double) * o_dim;
+
+  double* src_a = static_cast<double*>(sycl::malloc_shared(i_size, q));
+  double* src_b = static_cast<double*>(sycl::malloc_shared(i_size, q));
+  double* itmd = static_cast<double*>(sycl::malloc_shared(i_size, q));
+  double* dst = static_cast<double*>(sycl::malloc_shared(o_size, q));
+
+  // a = [1, 2, 3, 4, 5, 6, 7, 8]
+  // b = a
+  // n = len(a)
+  //
+  // now invoke
+  // https://github.com/tprest/falcon.py/blob/88d01ede1d7fa74a8392116bc5149dee57af93f2/ntrugen.py#L14
+  //
+  // res = [1, 4, 10, 20, 35, 56, 84, 120, 147, 164, 170, 164, 145, 112, 64, 0]
+  for (size_t i = 0; i < i_dim; i++) {
+    src_a[i] = i + 1;
+    src_b[i] = i + 1;
+  }
+
+  std::vector<sycl::event> evts = multiplication(
+    q, src_a, i_dim, src_b, i_dim, itmd, i_dim, dst, o_dim, wg_size, {});
+
+  q.ext_oneapi_submit_barrier(evts).wait();
+
+  for (size_t i = 0; i < o_dim; i++) {
+    assert(res[i] == dst[i]);
+  }
+
+  sycl::free(src_a, q);
+  sycl::free(src_b, q);
+  sycl::free(itmd, q);
+  sycl::free(dst, q);
+}
+
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,5 +1,6 @@
 #include "test_ff.hpp"
 #include "test_fft.hpp"
+#include "test_karatsuba.hpp"
 #include "test_ntt.hpp"
 #include "test_polynomial.hpp"
 #include <iostream>
@@ -27,7 +28,8 @@ main(int argc, char** argv)
             << test::mul(q, 1024, 32) << std::endl;
 
   test::ff_math(q);
-  std::cout << "[test] passed prime ( = 12289 ) field arithmetic test" << std::endl;
+  std::cout << "[test] passed prime ( = 12289 ) field arithmetic test"
+            << std::endl;
 
   test::ntt(q, 512, 32);
   std::cout << "[test] passed ntt test for size  512" << std::endl;
@@ -39,6 +41,9 @@ main(int argc, char** argv)
   std::cout << "[test] passed poly-mul test over Z_q of size  512" << std::endl;
   test::mul_zq(q, 1024, 32);
   std::cout << "[test] passed poly-mul test over Z_q of size 1024" << std::endl;
+
+  test::karatsuba(q);
+  std::cout << "[test] passed karatsuba polynomial multiplication" << std::endl;
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This PR implements data parallel variant of karatsuba polynomial multiplication, as recursively done [here](https://github.com/tprest/falcon.py/blob/88d01ede1d7fa74a8392116bc5149dee57af93f2/ntrugen.py#L14-L39), while taking inspiration from https://eprint.iacr.org/2006/224.pdf