### PR TITLE
On Device Pseudo Random Number Generation

### DIFF
--- a/include/common.hpp
+++ b/include/common.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "ff.hpp"
+#include <oneapi/dpl/random>
 #include <random>
 
 // Fill host accessible memory allocation with `dim` -many
@@ -47,13 +48,17 @@ bin_log(size_t n)
 // Returns `n` -many pseudorandom bytes, which are stored in allocated
 // memory ( designated by `bytes` )
 void
-random_bytes(const size_t n, uint8_t* const bytes)
+random_bytes(const size_t n,
+             uint8_t* const bytes,
+             const size_t seed,
+             const size_t offset // idx.get_global_linear_id()
+)
 {
-  std::random_device rd;
-  std::mt19937 gen(rd());
-  std::uniform_int_distribution<uint8_t> dis(0, 255);
+  // on device pseudo random number generation
+  oneapi::dpl::minstd_rand eng{ seed, offset };
+  oneapi::dpl::uniform_int_distribution<uint8_t> dis;
 
   for (size_t i = 0; i < n; i++) {
-    bytes[i] = dis(gen);
+    bytes[i] = dis(eng);
   }
 }

--- a/include/ntru_gen.hpp
+++ b/include/ntru_gen.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include "ff.hpp"
 #include "samplerz.hpp"
+#include <chrono>
+#include <oneapi/dpl/random>
 
 namespace ntru {
 
@@ -10,31 +12,67 @@ namespace ntru {
 // 1.17 * sqrt((double)ff::Q / (double)(4096 << 1))
 constexpr double SIGMA = 1.43300980528773;
 
-void
-gen_poly(const size_t dim,    // == {512, 1024}
-         int32_t* const itmd, // sizeof(int32_t) * 4096
-         int32_t* const poly  // sizeof(int32_t) * dim
-)
+// Generates polynomial of degree (dim - 1), with pseudo random coefficients
+// sampled from discrete Gaussian distribution D_{Z, 0, SIGMA}
+//
+// For on-device pseudo random number generation, I'm using Intel oneAPI DPL;
+// follow
+// https://www.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-library-guide/top/random-number-generator.html
+//
+// See step 1-6 of algorithm 5 in Falcon specification
+// https://falcon-sign.info/falcon.pdf
+std::vector<sycl::event>
+gen_poly(sycl::queue& q,
+         const size_t dim,     // == {512, 1024}
+         const size_t wg_size, // all work-groups effectively of same size
+         int32_t* const itmd,  // sizeof(int32_t) * 4096
+         int32_t* const poly,  // sizeof(int32_t) * dim
+         std::vector<sycl::event> evts)
 {
   assert((dim & (dim - 1)) == 0);
   assert(dim < 4096);
+  assert(dim % wg_size == 0);
+  assert(4096 % wg_size == 0);
 
-#pragma unroll 16
-  for (size_t i = 0; i < 4096; i++) {
-    itmd[i] = samplerz::samplerz(0., SIGMA, SIGMA - 0.001);
-  }
+  // seed for on-device random number generator
+  auto now = std::chrono::system_clock::now();
+  const uint64_t seed = std::chrono::duration_cast<std::chrono::microseconds>(
+                          now.time_since_epoch())
+                          .count();
+
+  sycl::event evt0 = q.submit([&](sycl::handler& h) {
+    h.depends_on(evts);
+    h.parallel_for(
+      sycl::nd_range<1>{ 4096, wg_size }, [=](sycl::nd_item<1> it) {
+        const size_t idx = it.get_global_linear_id();
+
+        // seed (pseudo) random number generator
+        oneapi::dpl::minstd_rand eng{ seed, idx };
+        oneapi::dpl::uniform_int_distribution<uint8_t> dis;
+
+        // each SYCL work-item uses its own random number generator,
+        // seeded with unique offset values
+        itmd[idx] = samplerz::samplerz(0., SIGMA, SIGMA - 0.001, eng, dis);
+      });
+  });
 
   const size_t k = 4096 / dim;
 
-#pragma unroll 16
-  for (size_t i = 0; i < dim; i++) {
-    int32_t sum = 0;
-    for (size_t j = 0; j < k; j++) {
-      sum += itmd[i * k + j];
-    }
+  sycl::event evt1 = q.submit([&](sycl::handler& h) {
+    h.depends_on(evt0);
+    h.parallel_for(sycl::nd_range<1>{ dim, wg_size }, [=](sycl::nd_item<1> it) {
+      const size_t idx = it.get_global_linear_id();
 
-    poly[i] = sum;
-  }
+      int32_t sum = 0;
+      for (size_t j = 0; j < k; j++) {
+        sum += itmd[idx * k + j];
+      }
+
+      poly[idx] = sum;
+    });
+  });
+
+  return { evt0, evt1 };
 }
 
 }

--- a/include/test_karatsuba.hpp
+++ b/include/test_karatsuba.hpp
@@ -3,8 +3,8 @@
 
 namespace test {
 
-// Tests data-parallel karatsuba polynomial multiplication implementation, **in a
-// static manner**
+// Tests data-parallel karatsuba polynomial multiplication implementation, **in
+// a static manner**
 //
 // @todo Improve test such that it can work for other input sizes and values.
 void


### PR DESCRIPTION
With help of Intel oneAPI DPL, I can now generate random numbers on accelerator ( read inside kernel body ) --- meaning `f`, `g` polynomial's coefficient generation can now be performed in data-parallel fashion.

See https://www.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-library-guide/top/random-number-generator.html for oneAPI DPL usage guide.