### PR TITLE
Fast Fourier Sampling

### DIFF
--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Get Dependency
+      run: git submodule update --init
     - name: Setup Compiler
       run: |
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10

--- a/include/ff.hpp
+++ b/include/ff.hpp
@@ -84,6 +84,17 @@ struct ff_t
     return ff_t{ t1 };
   }
 
+  // Adds one Z_q element with another one, while mutating the first one i.e.
+  // compound addition operation
+  constexpr void operator+=(const ff_t& rhs)
+  {
+    const uint16_t t0 = this->v + rhs.v;
+    const bool flg = t0 >= Q;
+    const uint16_t t1 = t0 - flg * Q;
+
+    this->v = t1;
+  }
+
   // Subtraction over prime field Z_q
   constexpr ff_t operator-(const ff_t& rhs) const
   {

--- a/include/ffsampling.hpp
+++ b/include/ffsampling.hpp
@@ -1,0 +1,86 @@
+#pragma once
+#include "falcon_tree.hpp"
+#include "polynomial.hpp"
+#include "samplerz.hpp"
+
+// Fast Fourier Sampling
+namespace ffsampling {
+
+// Given two polynomials t0, t1 ∈ FFT(Q[x]/ (x^N + 1)) i.e. in their FFT
+// representation and Falcon Tree T ( in its FFT representation ), this routine
+// computes two polynomials z0, z1 ∈ FFT (Z[x]/ (x^N + 1)), using algorithm 11 (
+// ffSampling ) as defined in Falcon specification
+// https://falcon-sign.info/falcon.pdf
+//
+// For understanding ffSampling, you should read section 3.9 of specification.
+template<const size_t N, const size_t AT_LEVEL, const size_t T_HEIGHT>
+static inline void
+ff_sampling(const fft::cmplx* const __restrict t0,
+            const fft::cmplx* const __restrict t1,
+            const fft::cmplx* const __restrict T,
+            const double σ_min,
+            fft::cmplx* const __restrict z0,
+            fft::cmplx* const __restrict z1)
+  requires((N > 0) && ((N & (N - 1)) == 0) && (N <= 1024) &&
+           (AT_LEVEL <= T_HEIGHT) && (N == (1ul << (T_HEIGHT - AT_LEVEL))))
+{
+  constexpr size_t node_cnt = 1ul << AT_LEVEL;
+  constexpr size_t tree_off = node_cnt * N;
+
+  if constexpr (N == 1) {
+    // deepest level of recursion !
+    static_assert(AT_LEVEL == T_HEIGHT, "Can't go below leaf level of tree !");
+
+    const double σ_prime = T[0].real();
+    const auto z0_ = samplerz::samplerz(t0[0].real(), σ_prime, σ_min);
+    const auto z1_ = samplerz::samplerz(t1[0].real(), σ_prime, σ_min);
+
+    z0[0] = fft::cmplx{ static_cast<double>(z0_) };
+    z1[0] = fft::cmplx{ static_cast<double>(z1_) };
+
+    return;
+  } else {
+    static_assert(AT_LEVEL < T_HEIGHT, "Can go to leaf level !");
+
+    const auto l = T;
+    const auto Tl = T + tree_off;
+    const auto Tr = Tl + (N / 2);
+    const auto z0l = z0;
+    const auto z1l = z1;
+    const auto z0r = z0l + (N / 2);
+    const auto z1r = z1l + (N / 2);
+
+    fft::cmplx t1_0[N / 2];
+    fft::cmplx t1_1[N / 2];
+
+    fft::split_fft<log2<N>()>(t1, t1_0, t1_1);
+    ff_sampling<N / 2, AT_LEVEL + 1, T_HEIGHT>(t1_0, t1_1, Tr, σ_min, z0r, z1r);
+
+    fft::cmplx merged_z1[N];
+    fft::merge_fft<log2<N / 2>()>(z0r, z1r, merged_z1);
+
+    fft::cmplx tmp0[N];
+    fft::cmplx tmp1[N];
+    polynomial::sub<log2<N>()>(t1, merged_z1, tmp0);
+    polynomial::mul<log2<N>()>(tmp0, l, tmp1);
+    polynomial::add<log2<N>()>(t0, tmp1, tmp0);
+
+    // t0' = tmp0
+
+    fft::cmplx t0_0[N / 2];
+    fft::cmplx t0_1[N / 2];
+
+    fft::split_fft<log2<N>()>(tmp0, t0_0, t0_1);
+    ff_sampling<N / 2, AT_LEVEL + 1, T_HEIGHT>(t0_0, t0_1, Tl, σ_min, z0l, z1l);
+
+    fft::cmplx merged_z0[N];
+    fft::merge_fft<log2<N / 2>()>(z0l, z1l, merged_z0);
+
+    std::memcpy(z0, merged_z0, sizeof(merged_z0));
+    std::memcpy(z1, merged_z1, sizeof(merged_z1));
+
+    return;
+  }
+}
+
+}

--- a/include/ffsampling.hpp
+++ b/include/ffsampling.hpp
@@ -57,7 +57,7 @@ ff_sampling(const fft::cmplx* const __restrict t0,
     ff_sampling<N / 2, AT_LEVEL + 1, T_HEIGHT>(t1_0, t1_1, Tr, σ_min, z0r, z1r);
 
     fft::cmplx merged_z1[N];
-    fft::merge_fft<log2<N / 2>()>(z0r, z1r, merged_z1);
+    fft::merge_fft<log2<N>()>(z0r, z1r, merged_z1);
 
     fft::cmplx tmp0[N];
     fft::cmplx tmp1[N];
@@ -74,7 +74,7 @@ ff_sampling(const fft::cmplx* const __restrict t0,
     ff_sampling<N / 2, AT_LEVEL + 1, T_HEIGHT>(t0_0, t0_1, Tl, σ_min, z0l, z1l);
 
     fft::cmplx merged_z0[N];
-    fft::merge_fft<log2<N / 2>()>(z0l, z1l, merged_z0);
+    fft::merge_fft<log2<N>()>(z0l, z1l, merged_z0);
 
     std::memcpy(z0, merged_z0, sizeof(merged_z0));
     std::memcpy(z1, merged_z1, sizeof(merged_z1));

--- a/include/fft.hpp
+++ b/include/fft.hpp
@@ -9,15 +9,6 @@ namespace fft {
 
 using cmplx = std::complex<double>;
 
-// Compile-time check to ensure that we're working with
-//
-// N ∈ [2..1024] && N = 2^k | k ∈ [1, 10]
-consteval bool
-check_log2n(const size_t lgn)
-{
-  return (lgn >= 1) && (lgn <= 10);
-}
-
 // Given a 64 -bit unsigned integer, this routine extracts specified many
 // contiguous bits from ( least significant bit ) LSB side & reverses their bit
 // order, returning bit reversed `mbw` -bit wide number
@@ -28,7 +19,7 @@ check_log2n(const size_t lgn)
 template<const size_t mbw>
 inline static constexpr size_t
 bit_rev(const size_t v)
-  requires(check_log2n(mbw))
+  requires((mbw > 0) && (mbw <= 10))
 {
   size_t v_rev = 0ul;
 
@@ -64,7 +55,7 @@ computeζ(const size_t k)
 template<const size_t LOG2N>
 inline void
 fft(cmplx* const __restrict vec)
-  requires(check_log2n(LOG2N))
+  requires((LOG2N > 0) && (LOG2N <= 10))
 {
   constexpr size_t N = 1ul << LOG2N;
 
@@ -99,7 +90,7 @@ fft(cmplx* const __restrict vec)
 template<const size_t LOG2N>
 inline void
 ifft(cmplx* const __restrict vec)
-  requires(check_log2n(LOG2N))
+  requires((LOG2N > 0) && (LOG2N <= 10))
 {
   constexpr size_t N = 1ul << LOG2N;
   constexpr double INV_N = 1. / static_cast<double>(N);
@@ -138,7 +129,7 @@ inline void
 split_fft(const cmplx* const __restrict f,
           cmplx* const __restrict f0,
           cmplx* const __restrict f1)
-  requires(check_log2n(LOG2N))
+  requires((LOG2N > 0) && (LOG2N <= 10))
 {
   constexpr size_t N = 1ul << LOG2N;
   constexpr size_t hN = N >> 1;
@@ -161,6 +152,7 @@ inline void
 merge_fft(const cmplx* const __restrict f0,
           const cmplx* const __restrict f1,
           cmplx* const __restrict f)
+  requires((LOG2N > 0) && (LOG2N <= 10))
 {
   constexpr size_t N = 1ul << LOG2N;
   constexpr size_t hN = N >> 1;
@@ -179,6 +171,7 @@ merge_fft(const cmplx* const __restrict f0,
 template<const size_t LOG2N>
 static inline void
 adj_poly(cmplx* const poly)
+  requires((LOG2N > 0) && (LOG2N <= 10))
 {
   constexpr size_t N = 1ul << LOG2N;
 

--- a/include/hashing.hpp
+++ b/include/hashing.hpp
@@ -5,28 +5,32 @@
 // Message Hashing for Falcon-{512, 1024}
 namespace hashing {
 
-// Given a message byte array of length `mlen` bytes, this function first
-// absorbs it into SHAKE256 XOF state and then computes a degree-(n-1)
-// polynomial over Z_q | q = 12289, by squeezing bytes out of keccak sponge
-// state. Note, n ∈ {512, 1024}.
+// Given uniform random sampled salt bytes ( of length `slen` ) and message of
+// length `mlen` bytes, this function first absorbs salt and message ( in order
+// ) into SHAKE256 XOF state and then computes a degree-(n-1) polynomial over
+// Z_q | q = 12289, by squeezing bytes out of keccak sponge state and rejection
+// sampling.
 //
 // This function is the implementation of algorithm 3, described in section 3.7,
 // on page 31 of Falcon specification https://falcon-sign.info/falcon.pdf
 template<const size_t n>
 inline void
-hash_to_point(const uint8_t* const __restrict msg,
+hash_to_point(const uint8_t* const __restrict salt,
+              const size_t slen,
+              const uint8_t* const __restrict msg,
               const size_t mlen,
               ff::ff_t* const __restrict poly)
+  requires((n == 512) || (n == 1024))
 {
-  static_assert((n == 512) || (n == 1024), "N must ∈ {512, 1024}");
-
   constexpr size_t m = 1ul << 16;
   constexpr size_t q = ff::Q;
   constexpr size_t k = m / q;
   constexpr uint16_t kq = k * q;
 
-  shake256::shake256 hasher{};
-  hasher.hash(msg, mlen);
+  shake256::shake256<true> hasher{};
+  hasher.absorb(salt, slen);
+  hasher.absorb(msg, mlen);
+  hasher.finalize();
 
   size_t i = 0;
   uint8_t buf[2];

--- a/include/polynomial.hpp
+++ b/include/polynomial.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "ff.hpp"
 #include "fft.hpp"
 #include "ntt.hpp"
 
@@ -28,6 +29,20 @@ template<const size_t lg2n>
 static inline void
 add_to(fft::cmplx* const __restrict polya,
        const fft::cmplx* const __restrict polyb)
+{
+  constexpr size_t n = 1ul << lg2n;
+
+  for (size_t i = 0; i < n; i++) {
+    polya[i] += polyb[i];
+  }
+}
+
+// Accumulate one degree-{(1 << lg2n) - 1} polynomial into another one ( of same
+// degree ), when both of them are in their NTT form, by performing element-wise
+// addition over Z_q
+template<const size_t lg2n>
+static inline void
+add_to(ff::ff_t* const __restrict polya, const ff::ff_t* const __restrict polyb)
 {
   constexpr size_t n = 1ul << lg2n;
 

--- a/include/test/test_falcon.hpp
+++ b/include/test/test_falcon.hpp
@@ -2,6 +2,7 @@
 
 #include "test_encoding.hpp"
 #include "test_ff.hpp"
+#include "test_ffsampling.hpp"
 #include "test_fft.hpp"
 #include "test_keygen.hpp"
 #include "test_ntru_gen.hpp"

--- a/include/test/test_ffsampling.hpp
+++ b/include/test/test_ffsampling.hpp
@@ -1,0 +1,140 @@
+#pragma once
+#include "ffsampling.hpp"
+#include "keygen.hpp"
+#include <cassert>
+
+// Test functional correctness of Falcon PQC suite implementation
+namespace test_falcon {
+
+// Check whether we can successfully generate two polynomials (s1, s2) each of
+// degree-N s.t. they satisfy the equation s1 + s2 * h = c ( mod q ), given
+// matrix B  = [[g, -f], [G, -F]] ( in its FFT representation ), falcon tree T (
+// in its FFT representation ) and falcon public key vector h ( in its
+// coefficient form ), which are generated using keygen function ( see
+// keygen.hpp file ).
+//
+// This function ensures that our implementation of ffSampling algorithm is
+// correct and it works as expected by attempting to **partially** implement
+// Falcon signing algorithm ( algo 10 in specification ).
+template<const size_t N>
+void
+test_ff_sampling(
+  const double σ,    // Standard deviation ( see table 3.3 of specification )
+  const double σ_min // See table 3.3 of specification
+  )
+  requires((N == 512) || (N == 1024))
+{
+  // 2^k * (1 + k) -many complex numbers required for storing Falcon tree of
+  // height k | k = log2(N)
+  constexpr size_t ft_len = (1ul << log2<N>()) * (log2<N>() + 1);
+  constexpr fft::cmplx q{ ff::Q };
+
+  auto B = static_cast<fft::cmplx*>(std::malloc(sizeof(fft::cmplx) * N * 4));
+  auto T = static_cast<fft::cmplx*>(std::malloc(sizeof(fft::cmplx) * ft_len));
+  auto h = static_cast<ff::ff_t*>(std::malloc(sizeof(ff::ff_t) * N));
+  auto h_fft = static_cast<fft::cmplx*>(std::malloc(sizeof(fft::cmplx) * N));
+  auto c = static_cast<ff::ff_t*>(std::malloc(sizeof(ff::ff_t) * N));
+  auto c_fft = static_cast<fft::cmplx*>(std::malloc(sizeof(fft::cmplx) * N));
+  auto t0 = static_cast<fft::cmplx*>(std::malloc(sizeof(fft::cmplx) * N));
+  auto t1 = static_cast<fft::cmplx*>(std::malloc(sizeof(fft::cmplx) * N));
+  auto z0 = static_cast<fft::cmplx*>(std::malloc(sizeof(fft::cmplx) * N));
+  auto z1 = static_cast<fft::cmplx*>(std::malloc(sizeof(fft::cmplx) * N));
+  auto tz0 = static_cast<fft::cmplx*>(std::malloc(sizeof(fft::cmplx) * N));
+  auto tz1 = static_cast<fft::cmplx*>(std::malloc(sizeof(fft::cmplx) * N));
+  auto s0 = static_cast<fft::cmplx*>(std::malloc(sizeof(fft::cmplx) * N));
+  auto s1 = static_cast<fft::cmplx*>(std::malloc(sizeof(fft::cmplx) * N));
+  auto s0_ntt = static_cast<ff::ff_t*>(std::malloc(sizeof(ff::ff_t) * N));
+  auto s1_ntt = static_cast<ff::ff_t*>(std::malloc(sizeof(ff::ff_t) * N));
+  auto tmp0 = static_cast<fft::cmplx*>(std::malloc(sizeof(fft::cmplx) * N));
+  auto tmp1 = static_cast<ff::ff_t*>(std::malloc(sizeof(ff::ff_t) * N));
+
+  // Falcon key generation, computes
+  //
+  // - Matrix B = [[g, -f], [G, -F]] ( FFT form )
+  // - Falcon tree T ( FFT form )
+  // - Falcon public key h ( Coeff Form )
+  keygen::keygen<N>(B, T, h, σ);
+
+  // Emulate line 2 of algorithm 10 of Falcon specification
+  for (size_t i = 0; i < N; i++) {
+    c[i] = ff::ff_t::random();
+  }
+  for (size_t i = 0; i < N; i++) {
+    c_fft[i] = fft::cmplx{ static_cast<double>(c[i].v) };
+  }
+
+  // compute t = (t0, t1) | see line 3 of algo 10 in the specification
+  fft::fft<log2<N>()>(c_fft);
+  polynomial::mul<log2<N>()>(c_fft, B + 3 * N, t0);
+  polynomial::mul<log2<N>()>(c_fft, B + N, t1);
+
+  for (size_t i = 0; i < N; i++) {
+    t0[i] /= q;
+    t1[i] = -(t1[i] / q);
+  }
+
+  // ffSampling i.e. compute z = (z0, z1), same as line 6 of algo 10
+  ffsampling::ff_sampling<N, 0, log2<N>()>(t0, t1, T, σ_min, z0, z1);
+
+  // compute tz = (tz0, tz1) = (t0 - z0, t1 - z1)
+  polynomial::sub<log2<N>()>(t0, z0, tz0);
+  polynomial::sub<log2<N>()>(t1, z1, tz1);
+
+  // compute s = (s0, s1) = tz * B | tz is 1x2 and B = 2x2 ( of dimension )
+  polynomial::mul<log2<N>()>(tz0, B, s0);
+  polynomial::mul<log2<N>()>(tz1, B + 2 * N, tmp0);
+  polynomial::add_to<log2<N>()>(s0, tmp0);
+  fft::ifft<log2<N>()>(s0);
+
+  polynomial::mul<log2<N>()>(tz0, B + N, s1);
+  polynomial::mul<log2<N>()>(tz1, B + 3 * N, tmp0);
+  polynomial::add_to<log2<N>()>(s1, tmp0);
+  fft::ifft<log2<N>()>(s1);
+
+  // Coefficients of s0, s1 ∈ [-6145, 6143], moving them to ∈ [0, 12289)
+  for (size_t i = 0; i < N; i++) {
+    const auto v0 = static_cast<int32_t>(std::round(s0[i].real()));
+    const auto v1 = static_cast<int32_t>(std::round(s1[i].real()));
+
+    s0_ntt[i].v = static_cast<uint16_t>((v0 < 0) * 12289 + v0);
+    s1_ntt[i].v = static_cast<uint16_t>((v1 < 0) * 12289 + v1);
+  }
+
+  ntt::ntt<log2<N>()>(s0_ntt);
+  ntt::ntt<log2<N>()>(s1_ntt);
+  ntt::ntt<log2<N>()>(h);
+
+  polynomial::mul<log2<N>()>(s1_ntt, h, tmp1); // tmp = s1 * h
+  polynomial::add_to<log2<N>()>(tmp1, s0_ntt); // tmp = s0 + tmp
+
+  ntt::intt<log2<N>()>(tmp1);
+
+  // ensure that s0 + s1 * h = c ( mod q ) satisfies !
+  bool match = true;
+  for (size_t i = 0; i < N; i++) {
+    match &= tmp1[i] == c[i];
+  }
+
+  std::free(B);
+  std::free(T);
+  std::free(h);
+  std::free(h_fft);
+  std::free(c);
+  std::free(c_fft);
+  std::free(t0);
+  std::free(t1);
+  std::free(z0);
+  std::free(z1);
+  std::free(tz0);
+  std::free(tz1);
+  std::free(s0);
+  std::free(s1);
+  std::free(s0_ntt);
+  std::free(s1_ntt);
+  std::free(tmp0);
+  std::free(tmp1);
+
+  assert(match);
+}
+
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -46,5 +46,9 @@ main()
   test_falcon::test_keygen<1024>();
   std::cout << "[test] Falcon KeyGen\n";
 
+  test_falcon::test_ff_sampling<512>(165.736617183, 1.277833697);
+  test_falcon::test_ff_sampling<1024>(168.388571447, 1.298280334);
+  std::cout << "[test] Fast Fourier Sampling\n";
+
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Given 

- A preimage `t` of `c` ( message hashed to a lattice point using _hashToPoint_ routine ) [ in FFT form ]
- Falcon tree `T` [ in FFT form ]
- 2x2 matrix `B = [[g, -f], [G, -F]]`  [ in FFT form ]
- Falcon public key `h` [ in coefficient form ]

ffSampling routine computes two short vectors `s1`, `s2` $∈ Z[x]/(φ)$ s.t. they satisfy `s1 + s2*h = c mod q | q = 12289`

---

Ensure correctness by running tests

```bash
make
```